### PR TITLE
Allow wider range of FFI dependency

### DIFF
--- a/tidy_ffi.gemspec
+++ b/tidy_ffi.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'ffi', "~> 1.2.0"
+  s.add_dependency 'ffi', "~> 1.2"
 end


### PR DESCRIPTION
The latest version of FFI for ruby 1.8.3 series  is 1.9.6 (tests still pass using this newer FFI version).. This doesn't change anything for existing installs but will allow wider compatibility.