### PR TITLE
Support libtidy in buster of architecture amd64

### DIFF
--- a/lib/tidy_ffi/lib_tidy.rb
+++ b/lib/tidy_ffi/lib_tidy.rb
@@ -4,7 +4,7 @@
 class TidyFFI::LibTidy #:nodoc:
   extend FFI::Library
 
-  paths = Array(TidyFFI.library_path || Dir['/{opt,usr}/{,local/}lib{,64}/libtidy{,-*}.{dylib,so*}'])
+  paths = Array(TidyFFI.library_path || Dir['/{opt,usr}/{,local/}lib{,64}/{,x86_64-linux-gnu/}libtidy{,-*}.{dylib,so*}'])
   begin
     ffi_lib(*paths)
   rescue LoadError

--- a/lib/tidy_ffi/lib_tidy.rb
+++ b/lib/tidy_ffi/lib_tidy.rb
@@ -4,9 +4,10 @@
 class TidyFFI::LibTidy #:nodoc:
   extend FFI::Library
 
-  paths = Array(TidyFFI.library_path || Dir['/{opt,usr}/{,local/}lib{,64}/{,x86_64-linux-gnu/}libtidy{,-*}.{dylib,so*}'])
+  LIB_NAME = 'tidy'.freeze
+  PATHS = Array([LIB_NAME] + Dir['/{opt,usr}/{,local/}lib{,64}/libtidy{,-*}.{dylib,so*}']).freeze
   begin
-    ffi_lib(*paths)
+    ffi_lib(TidyFFI.library_path || PATHS)
   rescue LoadError
     raise TidyFFI::LibTidyNotInstalled, "didn't find tidy libs on your system. Please install tidy (http://tidy.sourceforge.net/)"
   end


### PR DESCRIPTION
Hi, this add support for Debian buster libtidy path

cf https://packages.debian.org/buster/amd64/libtidy5deb1/filelist

Can be tested with this Dockerfile:

```
FROM debian:buster-slim

WORKDIR /usr/local/src
RUN set -ex \
    && apt-get update -qqy \
    && apt-get -qqy --no-install-recommends install \
        build-essential libtidy-dev ruby-dev bundler git \
    && apt-get purge -y \
    && apt-get autoremove -y \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
COPY . .
RUN bundle install
```

Cheers!